### PR TITLE
Fixing action for docker deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,5 +19,5 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
-          repository: revdotcom/fstalign
+          repository: revdotcom/fstalign/fstalign
           tag_with_ref: true


### PR DESCRIPTION
v1 of the docker BPA (build push action) requires repositories to have the format `:owner/:repo_name/:image_name`. Previously we were missing the image_name. This PR adds `fstalign` as the image name so that the image deployment can work again.