### PR TITLE
Migrating for Github packages to Docker Hub for container registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,4 +46,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: |
+            revdotcom/fstalign:latest
+            ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,17 +7,43 @@ jobs:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      - 
+        name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Checkout submodules
+      - 
+        name: Prepare tags
+        id: prep
+        run: |
+          DOCKER_IMAGE=revdotcom/fstalign
+          VERSION=develop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - 
+        name: Checkout submodules
         uses: textbook/git-checkout-submodule-action@2.1.1
 
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: revdotcom/fstalign/fstalign
-          tag_with_ref: true
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - 
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             revdotcom/fstalign:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             revdotcom/fstalign:latest

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ make test
 
 ### Docker
 
-The fstalign docker image is hosted on Github packages and can be pulled through:
+The fstalign docker image is hosted on Docker Hub and can be easily pulled:
 ```
-docker pull docker.pkg.github.com/revdotcom/fstalign/fstalign:1.0.0
+docker pull revdotcom/fstalign
 ```
 
-This docker image contains the source code, built dependencies, and the built binary. A container can be started using:
+See https://hub.docker.com/r/revdotcom/fstalign/tags for the available versions/tags to pull. This docker image contains the source code, built dependencies, and the built binary. A container can be started using:
 ```
-docker run --rm -it docker.pkg.github.com/revdotcom/fstalign/fstalign:1.0.0
+docker run --rm -it revdotcom/fstalign:1.0.0
 ```
 
 Additionally, if you desire to run the tool on local files you can mount local directories with the `-v` flag of the `docker run` command. Once the container is running, the binary is located at `/fstalign/build/fstalign`.


### PR DESCRIPTION
Using the revdotcom Docker Hub account to publish public `fstalign` docker images, for more convenient pulling (new image can be pulled anonymously).

Resolves #3 