### PR TITLE
Put wer tag entity type in SBS output

### DIFF
--- a/docs/Advanced-Usage.md
+++ b/docs/Advanced-Usage.md
@@ -72,6 +72,13 @@ Normalizations are a similar concept to synonyms. They allow a token or group of
 }
 ```
 
+### WER Sidecar
+
+CLI flag: `--wer-sidecar`
+
+Only usable for NLP format reference files. This passes a [WER sidecar](https://github.com/revdotcom/fstalign/blob/develop/docs//NLP-Format.md#WER%20tag%20sidecar) file to
+add extra information to some outputs. Optional.
+
 ## Outputs
 
 ### Text Log

--- a/docs/Advanced-Usage.md
+++ b/docs/Advanced-Usage.md
@@ -76,7 +76,7 @@ Normalizations are a similar concept to synonyms. They allow a token or group of
 
 CLI flag: `--wer-sidecar`
 
-Only usable for NLP format reference files. This passes a [WER sidecar](https://github.com/revdotcom/fstalign/blob/develop/docs//NLP-Format.md#WER%20tag%20sidecar) file to
+Only usable for NLP format reference files. This passes a [WER sidecar](https://github.com/revdotcom/fstalign/blob/develop/docs//NLP-Format.md#wer-tag-sidecar) file to
 add extra information to some outputs. Optional.
 
 ## Outputs

--- a/docs/NLP-Format.md
+++ b/docs/NLP-Format.md
@@ -26,3 +26,18 @@ quarter|0||||LC|['6:DATE']|['6']
 2020|0||||CA|['0:YEAR']|['0', '1', '6']
 NexGEn|0||||MC|['7:ORG']|['7']
 ```
+
+## WER tag sidecar
+
+WER tag sidecar files contain accompanying info for tokens in an NLP file. The
+keys are IDs corresponding to tokens in the NLP file `wer_tags` column. The
+objects under the keys are information about the token.
+
+Example:
+```
+{
+ '0': {'entity_type': 'YEAR'},
+ '1': {'entity_type': 'CARDINAL'},
+ '6': {'entity_type': 'SPACY>TIME'},
+}
+```

--- a/src/Nlp.h
+++ b/src/Nlp.h
@@ -42,8 +42,8 @@ class NlpReader {
 
 class NlpFstLoader : public FstLoader {
  public:
-  NlpFstLoader(std::vector<RawNlpRecord> &records, Json::Value normalization, bool processLabels);
-  NlpFstLoader(std::vector<RawNlpRecord> &records, Json::Value normalization);
+  NlpFstLoader(std::vector<RawNlpRecord> &records, Json::Value normalization, Json::Value wer_sidecar, bool processLabels);
+  NlpFstLoader(std::vector<RawNlpRecord> &records, Json::Value normalization, Json::Value wer_sidecar);
   virtual ~NlpFstLoader();
   virtual void addToSymbolTable(fst::SymbolTable &symbol) const;
   virtual fst::StdVectorFst convertToFst(const fst::SymbolTable &symbol, std::vector<int> map) const;
@@ -53,6 +53,7 @@ class NlpFstLoader : public FstLoader {
   vector<RawNlpRecord> mNlpRows;
   vector<std::string> mSpeakers;
   Json::Value mJsonNorm;
+  Json::Value mWerSidecar;
   virtual const std::string &getToken(int index) const { return mToken.at(index); }
 };
 

--- a/src/wer.cpp
+++ b/src/wer.cpp
@@ -327,16 +327,19 @@ void RecordTagWer(vector<shared_ptr<Stitching>> stitches) {
   for (auto &stitch : stitches) {
     if (!stitch->nlpRow.wer_tags.empty()) {
       for (auto wer_tag : stitch->nlpRow.wer_tags) {
-        wer_results.insert(std::pair<std::string, WerResult>(wer_tag, {0, 0, 0, 0, 0}));
+        int tag_start = wer_tag.find_first_not_of('#');
+        int tag_end = wer_tag.find('_');
+        string wer_tag_id = wer_tag.substr(tag_start, tag_end - tag_start);
+        wer_results.insert(std::pair<std::string, WerResult>(wer_tag_id, {0, 0, 0, 0, 0}));
         // Check with rfind since other comments can be there
         bool del = stitch->comment.rfind("del", 0) == 0;
         bool ins = stitch->comment.rfind("ins", 0) == 0;
         bool sub = stitch->comment.rfind("sub", 0) == 0;
-        wer_results[wer_tag].insertions += ins;
-        wer_results[wer_tag].deletions += del;
-        wer_results[wer_tag].substitutions += sub;
+        wer_results[wer_tag_id].insertions += ins;
+        wer_results[wer_tag_id].deletions += del;
+        wer_results[wer_tag_id].substitutions += sub;
         if (!ins) {
-          wer_results[wer_tag].numWordsInReference += 1;
+          wer_results[wer_tag_id].numWordsInReference += 1;
         }
       }
     }
@@ -503,7 +506,7 @@ void AddErrorGroup(ErrorGroups &groups, size_t &line, string &ref, string &hyp) 
   hyp = "";
 }
 
-void WriteSbs(spWERA topAlignment, string sbs_filename) {
+void WriteSbs(spWERA topAlignment, vector<shared_ptr<Stitching>> stitches, string sbs_filename) {
   auto logger = logger::GetOrCreateLogger("wer");
   logger->set_level(spdlog::level::info);
 
@@ -525,10 +528,16 @@ void WriteSbs(spWERA topAlignment, string sbs_filename) {
   std::set<std::string> op_set = {"<ins>", "<del>", "<sub>"};
 
   size_t offset = 2;  // line number in output file where first triple starts
-  while (visitor.NextTriple(tk_pair)) {
-    string tk_classLabel = tk_pair->classLabel;
-    string ref_tk = tk_pair->ref;
-    string hyp_tk = tk_pair->hyp;
+  /* while (visitor.NextTriple(tk_pair)) { */
+  for (auto p_stitch: stitches) {
+    string tk_classLabel = p_stitch->classLabel;
+    string tk_wer_tags = "";
+    auto wer_tags = p_stitch->nlpRow.wer_tags;
+    for (auto wer_tag: wer_tags) {
+      tk_wer_tags = tk_wer_tags + wer_tag + "|";
+    }
+    string ref_tk = p_stitch->reftk;
+    string hyp_tk = p_stitch->hyptk;
     string tag = "";
 
     if (ref_tk == NOOP) {
@@ -560,7 +569,7 @@ void WriteSbs(spWERA topAlignment, string sbs_filename) {
       eff_class = tk_classLabel;
     }
 
-    myfile << fmt::format("{0:>20}\t{1:20}\t{2}\t{3}", ref_tk, hyp_tk, tag, eff_class) << endl;
+    myfile << fmt::format("{0:>20}\t{1:20}\t{2}\t{3}\t{4}", ref_tk, hyp_tk, tag, eff_class, tk_wer_tags) << endl;
     offset++;
   }
 

--- a/src/wer.cpp
+++ b/src/wer.cpp
@@ -517,7 +517,7 @@ void WriteSbs(spWERA topAlignment, vector<shared_ptr<Stitching>> stitches, strin
   triple *tk_pair = new triple();
   string prev_tk_classLabel = "";
   logger->info("Side-by-Side alignment info going into {}", sbs_filename);
-  myfile << fmt::format("{0:>20}\t{1:20}\t{2}\t{3}", "ref_token", "hyp_token", "IsErr", "Class") << endl;
+  myfile << fmt::format("{0:>20}\t{1:20}\t{2}\t{3}\t{4}", "ref_token", "hyp_token", "IsErr", "Class", "Wer_Tag_Entities") << endl;
 
   // keep track of error groupings
   ErrorGroups groups_err;
@@ -528,7 +528,6 @@ void WriteSbs(spWERA topAlignment, vector<shared_ptr<Stitching>> stitches, strin
   std::set<std::string> op_set = {"<ins>", "<del>", "<sub>"};
 
   size_t offset = 2;  // line number in output file where first triple starts
-  /* while (visitor.NextTriple(tk_pair)) { */
   for (auto p_stitch: stitches) {
     string tk_classLabel = p_stitch->classLabel;
     string tk_wer_tags = "";

--- a/src/wer.h
+++ b/src/wer.h
@@ -48,4 +48,4 @@ void CalculatePrecisionRecall(spWERA &topAlignment, int threshold);
 typedef vector<pair<size_t, string>> ErrorGroups;
 
 void AddErrorGroup(ErrorGroups &groups, size_t &line, string &ref, string &hyp);
-void WriteSbs(spWERA topAlignment, string sbs_filename);
+void WriteSbs(spWERA topAlignment, vector<shared_ptr<Stitching>> stitches, string sbs_filename);

--- a/test/data/syn_1.hyp.sbs
+++ b/test/data/syn_1.hyp.sbs
@@ -1,28 +1,28 @@
            ref_token	hyp_token           	IsErr	Class
-                  we	<del>               	ERR	
-                will	we'll               	ERR	
-                have	have                		
-                   a	a                   		
-                nice	nice                		
-             evening	evening             		
-               <ins>	um                  	ERR	
-                  no	no                  		
-              matter	matter              		
-                what	what                		
-                will	will                		
-              happen	happen              		
-               <ins>	it                  	ERR	
-                  um	is                  	ERR	
-                it's	uh                  	ERR	
-                   a	a                   		
-                good	good                		
-         opportunity	opportunity         		
-                  to	to                  		
-                  do	<del>               	ERR	
-                this	this                		
-              you'll	you'll              		
-               <ins>	uh                  	ERR	
-                 see	see                 		
+                  we	<del>               	ERR		
+                will	we'll               	ERR		
+                have	have                			
+                   a	a                   			
+                nice	nice                			
+             evening	evening             			
+               <ins>	um                  	ERR		
+                  no	no                  			
+              matter	matter              			
+                what	what                			
+                will	will                			
+              happen	happen              			
+               <ins>	it                  	ERR		
+                  um	is                  	ERR		
+                it's	uh                  	ERR		
+                   a	a                   			
+                good	good                			
+         opportunity	opportunity         			
+                  to	to                  			
+                  do	<del>               	ERR		
+                this	this                			
+              you'll	you'll              			
+               <ins>	uh                  	ERR		
+                 see	see                 			
 ------------------------------------------------------------
                 Line	Group               
                    2	we will <-> we'll

--- a/test/data/syn_1.hyp.sbs
+++ b/test/data/syn_1.hyp.sbs
@@ -1,4 +1,4 @@
-           ref_token	hyp_token           	IsErr	Class
+           ref_token	hyp_token           	IsErr	Class	Wer_Tag_Entities
                   we	<del>               	ERR		
                 will	we'll               	ERR		
                 have	have                			

--- a/test/data/twenty.hyp-a2.sbs
+++ b/test/data/twenty.hyp-a2.sbs
@@ -1,13 +1,13 @@
            ref_token	hyp_token           	IsErr	Class
-                  20	<del>               	ERR	___1_CARDINAL___
-                  in	in                  		
-              twenty	twenty              		___2_YEAR___
-              twenty	thirty              	ERR	___2_YEAR___
-                  is	is                  		
-                 one	one                 		___3_CARDINAL___
-              twenty	twenty              		___3_CARDINAL___
-               <ins>	two                 	ERR	___3_CARDINAL___
-               three	three               		___3_CARDINAL___
+                  20	<del>               	ERR	___1_CARDINAL___	
+                  in	in                  			
+              twenty	twenty              		___2_YEAR___	
+              twenty	thirty              	ERR	___2_YEAR___	
+                  is	is                  			
+                 one	one                 		___3_CARDINAL___	
+              twenty	twenty              		___3_CARDINAL___	
+               <ins>	two                 	ERR	___3_CARDINAL___	
+               three	three               		___3_CARDINAL___	
 ------------------------------------------------------------
                 Line	Group               
                    2	20 <-> ***

--- a/test/data/twenty.hyp-a2.sbs
+++ b/test/data/twenty.hyp-a2.sbs
@@ -1,4 +1,4 @@
-           ref_token	hyp_token           	IsErr	Class
+           ref_token	hyp_token           	IsErr	Class	Wer_Tag_Entities
                   20	<del>               	ERR	___1_CARDINAL___	
                   in	in                  			
               twenty	twenty              		___2_YEAR___	

--- a/test/data/twenty.hyp.sbs
+++ b/test/data/twenty.hyp.sbs
@@ -1,13 +1,13 @@
            ref_token	hyp_token           	IsErr	Class
-              twenty	<del>               	ERR	___1_CARDINAL___
-                  in	in                  		
-              twenty	twenty              		___2_YEAR___
-              twenty	thirty              	ERR	___2_YEAR___
-                  is	is                  		
-                 one	one                 		___3_CARDINAL___
-              twenty	twenty              		___3_CARDINAL___
-               <ins>	two                 	ERR	___3_CARDINAL___
-               three	three               		___3_CARDINAL___
+              twenty	<del>               	ERR	___1_CARDINAL___	
+                  in	in                  			
+              twenty	twenty              		___2_YEAR___	
+              twenty	thirty              	ERR	___2_YEAR___	
+                  is	is                  			
+                 one	one                 		___3_CARDINAL___	
+              twenty	twenty              		___3_CARDINAL___	
+               <ins>	two                 	ERR	___3_CARDINAL___	
+               three	three               		___3_CARDINAL___	
 ------------------------------------------------------------
                 Line	Group               
                    2	twenty <-> ***

--- a/test/data/twenty.hyp.sbs
+++ b/test/data/twenty.hyp.sbs
@@ -1,4 +1,4 @@
-           ref_token	hyp_token           	IsErr	Class
+           ref_token	hyp_token           	IsErr	Class	Wer_Tag_Entities
               twenty	<del>               	ERR	___1_CARDINAL___	
                   in	in                  			
               twenty	twenty              		___2_YEAR___	


### PR DESCRIPTION
The WER tag sidecar file carries accompanying info for tokens in a NLP file. One such type of info is an "entity_type" like NER tags. This type of info is useful to see in the output SBS file.