### PR TITLE
Build: add compatibility with OpenFST 1.8.x and modern macOS (Apple Silicon)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 enable_testing()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(DEFINED ENV{OPENFST_ROOT})
@@ -41,7 +41,7 @@ set(OPENFST_INCLUDES
 
 if(DYNAMIC_OPENFST)
   set(OPENFST_LIBRARIES
-    ${OPENFST_ROOT}/lib/libfst.so
+    ${OPENFST_ROOT}/lib/libfst${CMAKE_SHARED_LIBRARY_SUFFIX}
   )
 else()
   set(OPENFST_LIBRARIES
@@ -69,7 +69,7 @@ add_library(fstaligner-common
   third-party/inih/cpp/INIReader.cpp
 )
 
-list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c") # for Mac users
+list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" "/opt/homebrew/opt/icu4c@78" "/opt/homebrew/opt/icu4c") # for Mac users
 find_package(ICU REQUIRED COMPONENTS uc)
 
 target_link_libraries(fstaligner-common
@@ -80,7 +80,15 @@ target_link_libraries(fstaligner-common
 )
 
 add_subdirectory(third-party/jsoncpp)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(jsoncpp_lib_static PRIVATE -Wno-implicit-int-float-conversion)
+endif()
 add_subdirectory(third-party/catch2)
+
+if(DYNAMIC_OPENFST)
+  set(CMAKE_BUILD_RPATH "${OPENFST_ROOT}/lib")
+  set(CMAKE_INSTALL_RPATH "${OPENFST_ROOT}/lib")
+endif()
 
 add_executable(fstalign src/main.cpp)
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ Finally, tests can be run using:
 make test
 ```
 
+### Building on macOS with OpenFST 1.8.x
+
+Homebrew's bundled `openfst` formula (in `openfst.rb`) provides 1.7.9 and conflicts
+with `homebrew/core/openfst`. Build OpenFST 1.8.x from source instead:
+
+```bash
+curl -L -O https://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.8.4.tar.gz
+tar xzf openfst-1.8.4.tar.gz
+cd openfst-1.8.4
+./configure --prefix="$HOME/opt/openfst-1.8.4" --disable-dependency-tracking
+make -j$(sysctl -n hw.logicalcpu) install
+```
+
+Then build fstalign pointing at the new prefix:
+
+```bash
+mkdir build && cd build
+cmake .. -DOPENFST_ROOT="$HOME/opt/openfst-1.8.4" -DDYNAMIC_OPENFST=ON
+make -j$(sysctl -n hw.logicalcpu)
+make test
+```
+
 ### Docker
 
 The fstalign docker image is hosted on Docker Hub and can be easily pulled and run:

--- a/src/AdaptedComposition.cpp
+++ b/src/AdaptedComposition.cpp
@@ -475,7 +475,7 @@ void AdaptedCompositionFst::SetSymbols(const fst::SymbolTable *symbols) {
   logger_->debug("{}:{} we created 2 vector<bool> of {} items", __FILE__, __LINE__, symbols->NumSymbols());
 
   for (SymbolTableIterator siter(*symbols); !siter.Done(); siter.Next()) {
-    int64 sid = siter.Value();
+    int64_t sid = siter.Value();
     auto sym_tk = symbols->Find(sid);
 
     if (isSynonymLabel(sym_tk)) {

--- a/src/AdaptedComposition.h
+++ b/src/AdaptedComposition.h
@@ -19,8 +19,8 @@ using namespace std;
 
 typedef fst::Fst<fst::StdArc>::StateId StateId;
 
-typedef pair<uint32, uint32> StatePair;
-struct key_hash : public std::unary_function<StatePair, std::size_t> {
+typedef pair<uint32_t, uint32_t> StatePair;
+struct key_hash {
   std::size_t operator()(const StatePair &k) const { return std::get<0>(k) ^ std::get<1>(k); }
 };
 

--- a/src/fstalign.cpp
+++ b/src/fstalign.cpp
@@ -35,7 +35,7 @@ class ReverseOLabelCompare {
     return std::forward_as_tuple(lhs.olabel, lhs.ilabel) > std::forward_as_tuple(rhs.olabel, rhs.ilabel);
   }
 
-  constexpr uint64 Properties(uint64 props) const {
+  constexpr uint64_t Properties(uint64_t props) const {
     return (props & kArcSortProperties) | kOLabelSorted | (props & kAcceptor ? kILabelSorted : 0);
   }
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,18 +21,18 @@ target_link_libraries(fstalign_Test Threads::Threads)
 
 add_test(NAME fstalign_Test
   COMMAND $<TARGET_FILE:fstalign_Test>
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/build)
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(compose-tests compose-tests.cc)
 target_link_libraries(compose-tests Threads::Threads)
 
 add_test(NAME compose-tests
   COMMAND $<TARGET_FILE:compose-tests>
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/build)
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(fast-d-tests fast-d-tests.cc)
 target_link_libraries(fast-d-tests Threads::Threads)
 
 add_test(NAME fast-d-tests
   COMMAND $<TARGET_FILE:fast-d-tests>
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/build)
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
OpenFST 1.8.x requires C++17 and dropped its own int64/uint32/uint64 typedef aliases in favour of the standard <cstdint> names. This commit updates the build system and source code to support both the new library version and Apple Silicon Macs running Homebrew under /opt/homebrew.

Changes:
- CMakeLists.txt: bump C++ standard to 17; use CMAKE_SHARED_LIBRARY_SUFFIX so -DDYNAMIC_OPENFST=ON works on macOS (.dylib) as well as Linux (.so); add /opt/homebrew ICU paths for Apple Silicon; embed RPATH so the binary finds libfst at runtime without DYLD_LIBRARY_PATH; guard the Clang-only -Wno-implicit-int-float-conversion suppression on jsoncpp
- test/CMakeLists.txt: replace hardcoded WORKING_DIRECTORY build/ with CMAKE_BINARY_DIR so tests work from any build directory name
- src/AdaptedComposition.h: uint32 -> uint32_t; remove std::unary_function base (removed in C++17)
- src/AdaptedComposition.cpp, src/StandardComposition.cpp: int64 -> int64_t
- src/fstalign.cpp: uint64 -> uint64_t
- third-party/strtk: mark pointer_ mutable so output iterator can advance inside a const operator() under C++17
- README.md: add macOS / OpenFST 1.8.x build instructions